### PR TITLE
Optimize dependency management

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -10,6 +10,7 @@
   "author": "@ziyasal sarikayaziya@gmail.com",
   "license": "MIT",
   "dependencies": {
+    "hapi": "^15.1.1",
     "hapijs-status-monitor": "../",
     "request": "^2.74.0"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "author": "@ziyasal sarikayaziya@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "hapi": "^14.2.0",
     "pidusage": "^1.0.4",
     "socket.io": "^1.4.8"
   }


### PR DESCRIPTION
I think the extension does not need the dependency `hapi` because we need it only for the example application.