### PR TITLE
Response time fixed

### DIFF
--- a/__tests__/helpers/on-headers-listener.spec.js
+++ b/__tests__/helpers/on-headers-listener.spec.js
@@ -16,7 +16,7 @@ describe('helpers', () => {
       });
 
       it('then for all spans, responses length should equal 1', () => {
-        onHeadersListener(404, process.hrtime(), spans);
+        onHeadersListener(404, Date.now(), spans);
 
         spans.forEach((span) => {
           expect(span.responses.length).toBe(1);
@@ -26,7 +26,7 @@ describe('helpers', () => {
       describe('when invoked after 1 second', () => {
         it('then for span interval 1, responses length should equal 2', () => {
           setTimeout(() => {
-            onHeadersListener(500, process.hrtime(), spans);
+            onHeadersListener(500, Date.now(), spans);
 
             spans.forEach((span) => {
               if (span.interval === 1) {

--- a/src/helpers/on-headers-listener.js
+++ b/src/helpers/on-headers-listener.js
@@ -1,6 +1,4 @@
-module.exports = (statusCode, startTime, spans) => {
-  const diff = process.hrtime(startTime);
-  const responseTime = ((diff[0] * 1e3) + diff[1]) * 1e-6;
+module.exports = (statusCode, responseTime, spans) => {
   const category = Math.floor(statusCode / 100);
 
   spans.forEach((span) => {

--- a/src/middleware-wrapper.js
+++ b/src/middleware-wrapper.js
@@ -37,11 +37,11 @@ const middlewareWrapper = (server, options, next) => {
       return reply.continue();
     }
 
-    const startTime = process.hrtime();
     const resp = request.response;
 
     resp.once('finish', () => {
-      onHeadersListener(resp.statusCode, startTime, opts.spans);
+      const tookMs = Date.now() - request.info.received;
+      onHeadersListener(resp.statusCode, tookMs, opts.spans);
     });
 
     return reply.continue();

--- a/src/public/javascripts/app.js
+++ b/src/public/javascripts/app.js
@@ -156,9 +156,9 @@ socket.on('start', function (data) {
 
   var lastResponseMetric = data[defaultSpan].responses[data[defaultSpan].responses.length - 1];
 
-  responseTimeStat.textContent = '0.00ms';
+  responseTimeStat.textContent = '0ms';
   if (lastResponseMetric) {
-    responseTimeStat.textContent = lastResponseMetric.mean.toFixed(2) + 'ms';
+    responseTimeStat.textContent = lastResponseMetric.mean.toFixed(0) + 'ms';
   }
 
   responseTimeChart.data.datasets[0].data = data[defaultSpan].responses.map(function (point) {
@@ -232,9 +232,9 @@ socket.on('stats', function (data) {
       loadChart.data.labels.push(os.timestamp);
     }
 
-    responseTimeStat.textContent = '0.00ms';
+    responseTimeStat.textContent = '0ms';
     if (responses) {
-      responseTimeStat.textContent = responses.mean.toFixed(2) + 'ms';
+      responseTimeStat.textContent = responses.mean.toFixed(0) + 'ms';
       responseTimeChart.data.datasets[0].data.push(responses.mean);
       responseTimeChart.data.labels.push(responses.timestamp);
     }


### PR DESCRIPTION
Hi, 
Thank you for this Hapi extension! I find it very useful and it helps me to monitor my microservices. 

Recently I discovered a possible bug or strange behaviour. The response times displayed on the status page do not correspond with any other response times measured by other means like developer tools in a browser or [good-console](https://github.com/hapijs/good-console) logging. 

It displays constantly times under 1ms, which is already strange. Especially, when all other tools display response times around 1.5s for my requests.

First, there were a computation flaw in the formula ` ((diff[0] * 1e3) + diff[1]) * 1e-6` => `((sec * 1e3 + nanos) * 1e-6` => `(ms + nanos) * 1e-6`. Basically a flaw in groupping of the parts. 

When I fixed that, I discovered that the start time is recorded too late, when the computation in routes is already finished, in the `onPreResponse` hook. So the time diff doesn't say anything about the processing time. But there is a `request.info.received` variable from Hapi, which marks the request start and we can compute the diff against it. 

After that correction, the response time displays realistic values. The presentation has to be adapted slightly and do not display decimal values, but this is just a design issue. 

![image](https://user-images.githubusercontent.com/4102775/32773752-7b3ffbf8-c92a-11e7-9a98-4441da90fb9a.png)

Could you please check my changes and consider to merge them? Thank you!

------------

It would be even possible to simplify the middleware-wrapper.js to something like:

```
server.on('response', function (request) {
    if (request.response.isBoom || request.path === opts.path) {
      return;
    }
    const tookMs = Date.now() - request.info.received;
    onHeadersListener(request.response.statusCode, tookMs, opts.spans);
});
```
to get even more precise response times, but this would need some additional refactoring. 