### PR TITLE
Added option for specifying the webscocket server instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Default options:
 ```js
 title: 'hapi.js Status',
 path: '/status',
+websocket: null, // The Socket.io instance to be used, if none provided a new one will be created!
 spans: [{
   interval: 1,     // Every second
   retention: 60    // Keep 60 datapoints in memory

--- a/src/helpers/default-config.js
+++ b/src/helpers/default-config.js
@@ -18,5 +18,6 @@ module.exports = {
       responses: [],
     },
   ],
+  websocket: null,
   routeConfig: {}, // https://github.com/hapijs/hapi/blob/master/API.md#route-options
 };

--- a/src/helpers/socket-io-init.js
+++ b/src/helpers/socket-io-init.js
@@ -5,18 +5,23 @@ const gatherOsMetrics = require('./gather-os-metrics');
 
 let io;
 
-module.exports = (server, spans) => {
+module.exports = (server, config) => {
   if (io === null || io === undefined) {
-    io = socketIo(server);
+    if (config.websocket) {
+      io = config.websocket;
+    } else {
+      io = socketIo(server);
+    }
 
     io.on('connection', (socket) => {
-      socket.emit('start', spans);
+      socket.emit('start', config.spans);
+
       socket.on('change', () => {
-        socket.emit('start', spans);
+        socket.emit('start', config.spans);
       });
     });
 
-    spans.forEach((currentSpan) => {
+    config.spans.forEach((currentSpan) => {
       const span = currentSpan;
       span.os = [];
       span.responses = [];

--- a/src/helpers/validate.js
+++ b/src/helpers/validate.js
@@ -23,5 +23,9 @@ module.exports = (config) => {
     cfg.routeConfig = defaultConfig.routeConfig;
   }
 
+  if (typeof cfg.websocket !== 'object') {
+    cfg.websocket = defaultConfig.websocket;
+  }
+
   return cfg;
 };

--- a/src/middleware-wrapper.js
+++ b/src/middleware-wrapper.js
@@ -10,7 +10,7 @@ const middlewareWrapper = (server, options) => {
 
   // Setup Socket.IO
   server.events.on('start', () => {
-    socketIoInit(server.listener, opts.spans);
+    socketIoInit(server.listener, opts);
   });
 
   server.route({


### PR DESCRIPTION
First of all, thank you for the wonderful Hapi plugin!

I came across with a situation where  I already had a running Socket.io server, and that alone was enough to crash the plugin.
The static frontend wasn't able to connect to the server, 'cos the new server won't accept connections, redirecting to the already existing instance, therefore all the event listeners won't be triggered.

This pull request simply adds an option to pass an instance of a Socket.io server on the plugin configuration, while maintaining the original functionality when not specified.